### PR TITLE
[EDIT]: Better 'reveal()' function

### DIFF
--- a/scripts/reveal.js
+++ b/scripts/reveal.js
@@ -1,17 +1,14 @@
 function reveal() {
-    var reveals = document.querySelectorAll(".reveal");
-  
-    for (var i = 0; i < reveals.length; i++) {
-      var windowHeight = window.innerHeight;
-      var elementTop = reveals[i].getBoundingClientRect().top;
-      var elementVisible = 150;
-  
-      if (elementTop < windowHeight - elementVisible) {
-        reveals[i].classList.add("active");
-      } else {
-        reveals[i].classList.remove("active");
-      }
-    }
-  }
-  
-  window.addEventListener("scroll", reveal);
+	let elms = document.querySelectorAll(".reveal");
+	let elmVisible = 150;
+
+	for (let i = 0; i < elms.length; i++) {
+		let elmTop = elms[i].getBoundingClientRect().top;
+		if (elmTop < window.innerHeight - elmVisible) {
+			elms[i].classList.add("active");
+		} else elms[i].classList.remove("active");
+	}
+}
+
+window.addEventListener("scroll", reveal);
+


### PR DESCRIPTION
- removed unnecessary variables
- 'var' to 'let' ('let' and 'var' are the same except for the fact that instead of being global, like 'var', 'let' is limited to the scope of its block)